### PR TITLE
Pin version of pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email="max.humber@gmail.com",
     license="MIT",
     py_modules=["gif"],
-    install_requires=["matplotlib", "Pillow"],
+    install_requires=["matplotlib", "Pillow<7"],
     python_requires=">=3.6",
     setup_requires=["setuptools>=38.6.0"],
 )


### PR DESCRIPTION
This package is great!  I've always found matplotlib's animation API lacking.

However, it seems that it is not compatible with the latest major release of pillow.  Here I've pinned it to < 7.