### PR TITLE
Add optional arguments to the save() methods

### DIFF
--- a/gif.py
+++ b/gif.py
@@ -16,7 +16,9 @@ class MissingExtension(Exception):
     pass
 
 
-def frame(*save_args, **save_kwargs):
+save_kwargs = {}
+
+def frame(func):
     """
     Decorator for a matplotlib plot function.
 
@@ -46,23 +48,21 @@ def frame(*save_args, **save_kwargs):
     Use the `save_args` and `save_kwargs` to pass additional arguments such
     as the dpi to the `plt.save()` and `altair_saver.save()` methods.
     """
-    def wrapper1(func):
-        def wrapper2(*args, **kwargs):
-            buffer = io.BytesIO()
-            plot = func(*args, **kwargs)
-            if "altair" in str(type(plot)):
-                if not altair_saver_installed:
-                    raise MissingExtension("pip install gif[altair]")
-                save_alt(plot, buffer, fmt="png", *save_args, **save_kwargs)
-            else:
-                plt.savefig(buffer, format="png", *save_args, **save_kwargs)
-                plt.close()
-            buffer.seek(0)
-            image = Image.open(buffer)
-            return image
+    def wrapper(*args, **kwargs):
+        buffer = io.BytesIO()
+        plot = func(*args, **kwargs)
+        if "altair" in str(type(plot)):
+            if not altair_saver_installed:
+                raise MissingExtension("pip install gif[altair]")
+            save_alt(plot, buffer, fmt="png", **save_kwargs)
+        else:
+            plt.savefig(buffer, format="png", **save_kwargs)
+            plt.close()
+        buffer.seek(0)
+        image = Image.open(buffer)
+        return image
 
-        return wrapper2
-    return wrapper1
+    return wrapper
 
 
 def save(frames, path, duration=100, fps=None, loop=0):

--- a/gif.py
+++ b/gif.py
@@ -65,13 +65,15 @@ def frame(*save_args, **save_kwargs):
     return wrapper1
 
 
-def save(frames, path, duration=100):
+def save(frames, path, duration=100, fps=None, loop=0):
     """
     Save decorated frames to an animated gif.
 
     - frames (list): collection of frames built with the frame decorator
     - path (str): filename with relative or absolute path
     - duration (int): milliseconds between frames
+    - fps (int): frames per second (takes precentence over `duration`)
+    - loop (int): number of times to loop the gif, 0 for inifinite
 
     Example:
     ```
@@ -81,11 +83,12 @@ def save(frames, path, duration=100):
         frames.append(frame)
     ```
     """
+    duration = 1000/fps if fps else duration
     frames[0].save(
         path,
         save_all=True,
         append_images=frames[1:],
         optimize=True,
         duration=duration,
-        loop=0,
+        loop=loop,
     )

--- a/gif.py
+++ b/gif.py
@@ -72,7 +72,7 @@ def save(frames, path, duration=100, fps=None, loop=0):
     - frames (list): collection of frames built with the frame decorator
     - path (str): filename with relative or absolute path
     - duration (int): milliseconds between frames
-    - fps (int): frames per second (takes precentence over `duration`)
+    - fps (int): frames per second (takes precedence over `duration`)
     - loop (int): number of times to loop the gif, 0 for inifinite
 
     Example:

--- a/tests/test_gif-matplotlib.py
+++ b/tests/test_gif-matplotlib.py
@@ -3,26 +3,29 @@ from matplotlib import pyplot as plt
 from PIL import Image
 import gif
 
+@gif.frame
+def plot(x, y):
+    plt.scatter(x, y)
 
 def test_frame():
-    @gif.frame
-    def plot(x, y):
-        plt.scatter(x, y)
-
     frame = plot([0, 5], [0, 5])
     assert str(type(frame)) == "<class 'PIL.PngImagePlugin.PngImageFile'>"
 
-
 @pytest.fixture(scope="session")
 def saved_gif():
-    @gif.frame
-    def plot(x, y):
-        plt.scatter(x, y)
-
     frames = [plot([0, 5], [0, 5]), plot([0, 10], [0, 10])]
     gif.save(frames, "test-matplotlib.gif")
 
+@pytest.fixture(scope="session")
+def saved_gif_kwargs():
+    gif.save_kwargs['dpi'] = 200
+    frames = [plot([0, 5], [0, 5]), plot([0, 10], [0, 10])]
+    gif.save(frames, "test-matplotlib2.gif")
 
 def test_save(saved_gif):
     im = Image.open("test-matplotlib.gif")
+    assert im.format == "GIF"
+
+def test_save_kwargs(saved_gif_kwargs):
+    im = Image.open("test-matplotlib2.gif")
     assert im.format == "GIF"


### PR DESCRIPTION
The following adds another wrapper layer to allow for arguments in the decorator
```
@gif.frame(*a, **kw)
def function():
  ...
```
Arguments passed directly to the decoratror will be used when invoking `plt.save()`, which for example allows changing the dpi of the plots.

While at it, I also added more kwargs to the `gif.save` method.