### PR TITLE
pass `optimize` to Frame.save

### DIFF
--- a/gif.py
+++ b/gif.py
@@ -108,7 +108,7 @@ def save(
         path,
         save_all=True,
         append_images=frames[1:],
-        optimize=True,
+        optimize=optimize,
         duration=duration,
         disposal=0 if overlapping else 2,
         loop=0,


### PR DESCRIPTION
Hi! 
Looks like the `optimize` param isn't being passed to pillow on `gif.save`.

Is there a reason why you have your own optimization routine and set the pillow default to `True`? I'm trying to make a gif that syncs up to some audio but I believe this forced optimization causes  frames to be dropped and the gif to go out of sync. 

I just now realize an issue would've been better to open than a PR. just a sleepy early morning mistake. sorry about that!